### PR TITLE
#165594413 Fix the account details route

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,10 +5,8 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
+import swaggerdoc from '../swagger';
 import router from './router/router';
-
-
-const swaggerdoc = require('../swagger');
 
 const app = express();
 

--- a/server/controllers/accountController.js
+++ b/server/controllers/accountController.js
@@ -141,11 +141,14 @@ class AccountController {
     */
 
   static async getAccountDetails(req, res) {
-    const { param } = req.body;
+    const { param, loggedinUser } = req.body;
     let Accountdetails; const accountNumber = param;
 
     try {
-      Accountdetails = await pool.query(queries.join.accountOnEmail, [accountNumber]);
+      if (loggedinUser.type === 'client') {
+        Accountdetails = await pool.query(queries.join.accountsAndEmailOnId,
+          [loggedinUser.id, accountNumber]);
+      } else Accountdetails = await pool.query(queries.join.accountOnEmail, [accountNumber]);
 
       if (!Accountdetails.rows[0]) {
         return util.errorstatus(res, 400, 'Account not found');

--- a/server/migrations/queries.js
+++ b/server/migrations/queries.js
@@ -23,6 +23,7 @@ const queries = {
   join: {
     accountOnEmail: 'SELECT email, accounts.* FROM users INNER JOIN accounts on users.id = accounts.OWNER WHERE accounts.accountnumber = $1',
     accountsAndEmail: 'SELECT email, accounts.* FROM users INNER JOIN accounts on users.id = accounts.OWNER',
+    accountsAndEmailOnId: 'SELECT email, accounts.* FROM users INNER JOIN accounts on users.id = accounts.OWNER where users.id = $1 AND accounts.accountnumber = $2',
     getAllDormant: 'SELECT email, accounts.* FROM users INNER JOIN accounts on users.id = accounts.OWNER WHERE accounts.status = \'dormant\'',
     getAllActive: 'SELECT email, accounts.* FROM users INNER JOIN accounts on users.id = accounts.OWNER WHERE accounts.status = \'active\'',
   },

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -54,7 +54,6 @@ describe('Banka App', () => {
         .post(`${baseUrl}/auth/signup`)
         .send(users[4])
         .end((err, res) => {
-          userToken = res.body.data.token;
           expect(res.body).to.not.equal(null);
           expect(res.statusCode).to.equal(201);
           done();
@@ -114,6 +113,18 @@ describe('Banka App', () => {
         .send(users[7])
         .end((err, res) => {
           staffToken = res.body.data.token;
+          expect(res.body.data).to.not.equal(null);
+          expect(res.statusCode).to.equal(200);
+          done();
+        });
+    });
+
+    it('should signin an existing user(Client)', (done) => {
+      chai.request(app)
+        .post(`${baseUrl}/auth/signin`)
+        .send(users[1])
+        .end((err, res) => {
+          userToken = res.body.data.token;
           expect(res.body.data).to.not.equal(null);
           expect(res.statusCode).to.equal(200);
           done();
@@ -519,6 +530,17 @@ describe('Banka App', () => {
       chai.request(app)
         .get(`${baseUrl}/accounts/1010101019`)
         .set('authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          expect(res.body.data).to.not.equal(null);
+          expect(res.statusCode).to.equal(200);
+          done();
+        });
+    });
+
+    it('should return only the specific details on an account to the owner', (done) => {
+      chai.request(app)
+        .get(`${baseUrl}/accounts/1010101011`)
+        .set('authorization', `Bearer ${userToken}`)
         .end((err, res) => {
           expect(res.body.data).to.not.equal(null);
           expect(res.statusCode).to.equal(200);


### PR DESCRIPTION
**What does this PR do?**
>- Fixes the account details route

**Description of Task to be completed?**
>- Allow the account details route to give specific account details belonging to a user, to that user alone.
>- Route should continue as before and give all accounts details to staff/admin

**How should this be manually tested?**
>- Clone the repo and run npm install to download all packages, then use npm run test to test the 
     endpoint, POSTMAN can also be used to test.

**Any background context you want to provide?**
>- None

**What are the relevant pivotal tracker stories?**
>- <a href = "https://www.pivotaltracker.com/story/show/165594413">#165594413</a>

**Screenshots (if appropriate)**
>- None